### PR TITLE
Auth routing mobile

### DIFF
--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -1,8 +1,9 @@
-import React from 'react';
+import React, {useEffect} from 'react';
 import {SafeAreaView, StatusBar, useColorScheme} from 'react-native';
 import Navigator from './src/router/Navigator';
 import {Provider} from 'react-redux';
 import store from './src/store';
+import {loadUser} from './src/actions/auth';
 
 const App = () => {
   const isDarkMode = useColorScheme() === 'dark';
@@ -11,6 +12,11 @@ const App = () => {
     flex: 1,
     backgroundColor: '#00c1ff',
   };
+
+  useEffect(() => {
+    // @ts-ignore
+    store.dispatch(loadUser());
+  }, []);
 
   return (
     <Provider store={store}>

--- a/mobile/src/actions/auth/index.ts
+++ b/mobile/src/actions/auth/index.ts
@@ -12,6 +12,7 @@ import {
   REGISTER_SUCCESS,
   USER_LOADED,
   USER_LOADING,
+  AUTHENTICATING,
 } from '../types';
 import {getErrors} from '../error';
 
@@ -19,7 +20,7 @@ export const signup =
   (formData: IRegisterFormData, navigation: any) =>
   async (dispatch: Dispatch<any>) => {
     try {
-      dispatch({type: USER_LOADING});
+      dispatch({type: AUTHENTICATING});
 
       const {data} = await api.register(formData);
       dispatch({type: REGISTER_SUCCESS, data});
@@ -41,7 +42,7 @@ export const login =
   (formData: ILoginFormData, navigation: any) =>
   async (dispatch: Dispatch<any>) => {
     try {
-      dispatch({type: USER_LOADING});
+      dispatch({type: AUTHENTICATING});
       const {data} = await api.authenticate(formData);
 
       dispatch({type: LOGIN_SUCCESS, data});

--- a/mobile/src/actions/auth/index.ts
+++ b/mobile/src/actions/auth/index.ts
@@ -58,7 +58,6 @@ export const login =
 
 export const loadUser = () => async (dispatch: Dispatch<any>) => {
   try {
-    console.log('asd');
     dispatch({type: USER_LOADING});
     const {data} = await api.getUserData();
     dispatch({type: USER_LOADED, payload: data});

--- a/mobile/src/actions/auth/index.ts
+++ b/mobile/src/actions/auth/index.ts
@@ -58,6 +58,7 @@ export const login =
 
 export const loadUser = () => async (dispatch: Dispatch<any>) => {
   try {
+    console.log('asd');
     dispatch({type: USER_LOADING});
     const {data} = await api.getUserData();
     dispatch({type: USER_LOADED, payload: data});

--- a/mobile/src/actions/types.ts
+++ b/mobile/src/actions/types.ts
@@ -14,6 +14,8 @@ export const LOGIN_FAIL = 'AUTH/LOGIN_FAIL';
 
 export const LOGOUT_SUCCESS = 'AUTH/LOGOUT_SUCCESS';
 
+export const AUTHENTICATING = 'AUTH/AUTHENTINCATING';
+
 export const GET_ERRORS = 'ERRORS/GET';
 export const CLEAR_ERRORS = 'ERRORS/CLEAR';
 

--- a/mobile/src/components/common/Loader.tsx
+++ b/mobile/src/components/common/Loader.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import {ActivityIndicator, StyleSheet, View} from 'react-native';
+
+const Loader = () => (
+  <View style={[styles.container, styles.horizontal]}>
+    <ActivityIndicator size='large' />
+  </View>
+);
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+  },
+  horizontal: {
+    flexDirection: 'row',
+    justifyContent: 'space-around',
+    padding: 10,
+  },
+});
+
+export default Loader;

--- a/mobile/src/components/common/Loader.tsx
+++ b/mobile/src/components/common/Loader.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import {ActivityIndicator, StyleSheet, View} from 'react-native';
+import {ActivityIndicator, StyleSheet, View, Text} from 'react-native';
 
 const Loader = () => (
   <View style={[styles.container, styles.horizontal]}>
-    <ActivityIndicator size='large' />
+    <ActivityIndicator size={80} color='#20323A' />
   </View>
 );
 

--- a/mobile/src/reducers/auth/index.ts
+++ b/mobile/src/reducers/auth/index.ts
@@ -8,6 +8,7 @@ import {
   REGISTER_SUCCESS,
   USER_LOADED,
   USER_LOADING,
+  AUTHENTICATING,
 } from '../../actions/types';
 
 export interface IProfileData {
@@ -26,12 +27,14 @@ export interface IAuthState {
   profile: null | IProfileData;
   isAuthenticated: boolean;
   isLoading: boolean;
+  isAuthenticating: boolean;
 }
 
 const initialState: IAuthState = {
   profile: null,
   isAuthenticated: false,
   isLoading: true,
+  isAuthenticating: false,
 };
 
 const authReducer = (
@@ -52,7 +55,11 @@ const authReducer = (
         isLoading: false,
         profile: action.data,
       };
-
+    case AUTHENTICATING:
+      return {
+        ...state,
+        isAuthenticating: true,
+      };
     case LOGIN_SUCCESS:
     case REGISTER_SUCCESS:
       (async () => {
@@ -63,6 +70,7 @@ const authReducer = (
         ...action.data,
         isAuthenticated: true,
         isLoading: false,
+        isAuthenticating: false,
       };
 
     case AUTH_ERROR:
@@ -77,6 +85,7 @@ const authReducer = (
         profile: null,
         isAuthenticated: false,
         isLoading: false,
+        isAuthenticating: false,
       };
 
     default:

--- a/mobile/src/reducers/auth/index.ts
+++ b/mobile/src/reducers/auth/index.ts
@@ -31,7 +31,7 @@ export interface IAuthState {
 const initialState: IAuthState = {
   profile: null,
   isAuthenticated: false,
-  isLoading: false,
+  isLoading: true,
 };
 
 const authReducer = (

--- a/mobile/src/router/DrawerNavigator.tsx
+++ b/mobile/src/router/DrawerNavigator.tsx
@@ -5,66 +5,106 @@ import Search from '../screens/properties/Search';
 import Onboarding from '../screens/auth/Onboarding';
 import MaterialCommunityIcons from 'react-native-vector-icons/MaterialCommunityIcons';
 import Ionicons from 'react-native-vector-icons/Ionicons';
+import {connect} from 'react-redux';
 
 const Drawer = createDrawerNavigator();
 
-const DrawerNavigator = () => {
-  return (
-    <Drawer.Navigator
-      drawerType='front'
-      initialRouteName='Profile'
-      screenOptions={{
-        activeTintColor: '#e91e63',
-        drawerInactiveTintColor: 'white',
-        itemStyle: {marginVertical: 10},
-        drawerStyle: {
-          backgroundColor: '#20323A',
-        },
-      }}>
-      <Drawer.Screen
-        key='Login'
-        name='Login'
-        component={Login}
-        options={{
-          drawerIcon: ({focused}) => (
-            <MaterialCommunityIcons
-              name='face'
-              size={24}
-              color={focused ? '#5FACF2' : 'white'}
-            />
-          ),
-        }}
-      />
-      <Drawer.Screen
-        key='Onboarding'
-        name='Onboarding'
-        component={Onboarding}
-        options={{
-          drawerIcon: ({focused}) => (
-            <Ionicons
-              name='notifications'
-              size={24}
-              color={focused ? '#5FACF2' : 'white'}
-            />
-          ),
-        }}
-      />
-      <Drawer.Screen
-        key='Search'
-        name='Search'
-        component={Search}
-        options={{
-          drawerIcon: ({focused}) => (
-            <Ionicons
-              name='search'
-              size={24}
-              color={focused ? '#5FACF2' : 'white'}
-            />
-          ),
-        }}
-      />
-    </Drawer.Navigator>
-  );
+interface IDrawerProps {
+  isAuthenticated: boolean;
+}
+
+const DrawerNavigator = ({isAuthenticated}: IDrawerProps) => {
+  if (isAuthenticated) {
+    return (
+      <Drawer.Navigator
+        drawerType='front'
+        initialRouteName='Profile'
+        screenOptions={{
+          activeTintColor: '#e91e63',
+          drawerInactiveTintColor: 'white',
+          itemStyle: {marginVertical: 10},
+          drawerStyle: {
+            backgroundColor: '#20323A',
+          },
+        }}>
+        <Drawer.Screen
+          key='Login'
+          name='Login'
+          component={Login}
+          options={{
+            drawerIcon: ({focused}) => (
+              <MaterialCommunityIcons
+                name='face'
+                size={24}
+                color={focused ? '#5FACF2' : 'white'}
+              />
+            ),
+          }}
+        />
+        <Drawer.Screen
+          key='Onboarding'
+          name='Onboarding'
+          component={Onboarding}
+          options={{
+            drawerIcon: ({focused}) => (
+              <Ionicons
+                name='notifications'
+                size={24}
+                color={focused ? '#5FACF2' : 'white'}
+              />
+            ),
+          }}
+        />
+        <Drawer.Screen
+          key='Search'
+          name='Search'
+          component={Search}
+          options={{
+            drawerIcon: ({focused}) => (
+              <Ionicons
+                name='search'
+                size={24}
+                color={focused ? '#5FACF2' : 'white'}
+              />
+            ),
+          }}
+        />
+      </Drawer.Navigator>
+    );
+  } else {
+    return (
+      <Drawer.Navigator
+        drawerType='front'
+        initialRouteName='Profile'
+        screenOptions={{
+          activeTintColor: '#e91e63',
+          drawerInactiveTintColor: 'white',
+          itemStyle: {marginVertical: 10},
+          drawerStyle: {
+            backgroundColor: '#20323A',
+          },
+        }}>
+        <Drawer.Screen
+          key='Login'
+          name='Login'
+          component={Login}
+          options={{
+            drawerIcon: ({focused}) => (
+              <MaterialCommunityIcons
+                name='face'
+                size={24}
+                color={focused ? '#5FACF2' : 'white'}
+              />
+            ),
+          }}
+        />
+      </Drawer.Navigator>
+    );
+  }
 };
 
-export default DrawerNavigator;
+const mapStateToProps = (state: any) => ({
+  isAuthenticated: state.auth.isAuthenticated,
+});
+
+export default connect(mapStateToProps, {})(DrawerNavigator);

--- a/mobile/src/router/Navigator.tsx
+++ b/mobile/src/router/Navigator.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import {connect} from 'react-redux';
 import {NavigationContainer} from '@react-navigation/native';
 import {createNativeStackNavigator} from '@react-navigation/native-stack';
 import Login from '../screens/auth/Login';
@@ -7,10 +8,28 @@ import RegisterStepOne from '../screens/auth/Register/RegisterStepOne';
 import RegisterStepTwo from '../screens/auth/Register/RegisterStepTwo';
 import DrawerNavigator from './DrawerNavigator';
 import UserProfile from '../screens/user/UserProfile';
+import Loader from '../components/common/Loader';
 
 const Stack = createNativeStackNavigator();
 
-const Navigator = () => {
+interface INavigatorProps {
+  isAuthenticated: boolean;
+  isLoading: boolean;
+}
+
+const Navigator = ({isAuthenticated, isLoading}: INavigatorProps) => {
+  if (isLoading) {
+    return (
+      <NavigationContainer>
+        <Stack.Screen
+          name='Loading'
+          component={Loader}
+          options={{headerShown: false}}
+        />
+      </NavigationContainer>
+    );
+  }
+
   return (
     <NavigationContainer>
       <Stack.Navigator>
@@ -67,4 +86,9 @@ const Navigator = () => {
   );
 };
 
-export default Navigator;
+const mapStateToProps = (state: any) => ({
+  isAuthenticated: state.auth.isAuthenticated,
+  isLoading: state.auth.isLoading,
+});
+
+export default connect(mapStateToProps, {})(Navigator);

--- a/mobile/src/router/Navigator.tsx
+++ b/mobile/src/router/Navigator.tsx
@@ -19,71 +19,96 @@ interface INavigatorProps {
 
 const Navigator = ({isAuthenticated, isLoading}: INavigatorProps) => {
   if (isLoading) {
+    return <Loader />;
+  }
+
+  if (isAuthenticated) {
     return (
       <NavigationContainer>
-        <Stack.Screen
-          name='Loading'
-          component={Loader}
-          options={{headerShown: false}}
-        />
+        <Stack.Navigator>
+          <Stack.Screen
+            name='Drawer'
+            component={DrawerNavigator}
+            options={{headerShown: false}}
+          />
+          <Stack.Screen
+            name='Login'
+            component={Login}
+            options={{headerShown: false}}
+          />
+          <Stack.Screen
+            name='RegisterStepOne'
+            component={RegisterStepOne}
+            options={{headerShown: false}}
+          />
+          <Stack.Screen
+            name='SignupStep2'
+            component={RegisterStepTwo}
+            options={{
+              title: '',
+              headerStyle: {
+                backgroundColor: '#057699',
+              },
+              headerTintColor: '#fff',
+              headerTitleStyle: {
+                fontWeight: 'bold',
+              },
+            }}
+          />
+          <Stack.Screen
+            name='Onboarding'
+            component={Onboarding}
+            options={{headerShown: false}}
+          />
+          <Stack.Screen
+            name='UserProfile'
+            component={UserProfile}
+            options={{
+              title: '',
+              headerStyle: {
+                backgroundColor: '#005679',
+              },
+              headerTintColor: '#fff',
+              headerTitleStyle: {
+                fontWeight: 'bold',
+              },
+            }}
+          />
+        </Stack.Navigator>
+      </NavigationContainer>
+    );
+  } else {
+    return (
+      <NavigationContainer>
+        <Stack.Navigator>
+          <Stack.Screen
+            name='Login'
+            component={Login}
+            options={{headerShown: false}}
+          />
+          <Stack.Screen
+            name='RegisterStepOne'
+            component={RegisterStepOne}
+            options={{headerShown: false}}
+          />
+          <Stack.Screen
+            name='SignupStep2'
+            component={RegisterStepTwo}
+            options={{
+              title: '',
+              headerStyle: {
+                backgroundColor: '#057699',
+              },
+              headerTintColor: '#fff',
+              headerTitleStyle: {
+                fontWeight: 'bold',
+              },
+            }}
+          />
+        </Stack.Navigator>
       </NavigationContainer>
     );
   }
-
-  return (
-    <NavigationContainer>
-      <Stack.Navigator>
-        <Stack.Screen
-          name='Drawer'
-          component={DrawerNavigator}
-          options={{headerShown: false}}
-        />
-        <Stack.Screen
-          name='Login'
-          component={Login}
-          options={{headerShown: false}}
-        />
-        <Stack.Screen
-          name='RegisterStepOne'
-          component={RegisterStepOne}
-          options={{headerShown: false}}
-        />
-        <Stack.Screen
-          name='SignupStep2'
-          component={RegisterStepTwo}
-          options={{
-            title: '',
-            headerStyle: {
-              backgroundColor: '#057699',
-            },
-            headerTintColor: '#fff',
-            headerTitleStyle: {
-              fontWeight: 'bold',
-            },
-          }}
-        />
-        <Stack.Screen
-          name='Onboarding'
-          component={Onboarding}
-          options={{headerShown: false}}
-        />
-        <Stack.Screen
-          name='UserProfile'
-          component={UserProfile}
-          options={{
-            title: '',
-            headerStyle: {
-              backgroundColor: '#005679',
-            },
-            headerTintColor: '#fff',
-            headerTitleStyle: {
-              fontWeight: 'bold',
-            },
-          }}
-        />
-      </Stack.Navigator>
-    </NavigationContainer>
-  );
 };
 
 const mapStateToProps = (state: any) => ({

--- a/mobile/src/screens/auth/Login.tsx
+++ b/mobile/src/screens/auth/Login.tsx
@@ -29,7 +29,7 @@ interface ILoginProps {
   loadUser: Function;
   error: IError;
   isAuthenticated: boolean;
-  isLoading: boolean;
+  isAuthenticating: boolean;
   clearErrors: Function;
   getErrors: Function;
   navigation: any;
@@ -50,7 +50,7 @@ const Login = ({
   login,
   error,
   isAuthenticated,
-  isLoading,
+  isAuthenticating,
   clearErrors,
   getErrors,
   loadUser,
@@ -149,7 +149,7 @@ const Login = ({
         )}
         <View style={styles.mainCTAContainer}>
           <TouchableOpacity style={styles.mainCTA} onPress={onSubmit}>
-            {isLoading && (
+            {isAuthenticating && (
               <ActivityIndicator
                 style={{
                   left: wp(-15),
@@ -190,7 +190,7 @@ const Login = ({
 const mapStateToProps = (state: any) => ({
   error: state.error,
   isAuthenticated: state.auth.isAuthenticated,
-  isLoading: state.auth.isLoading,
+  isAuthenticating: state.auth.isAuthenticating,
 });
 
 export default connect(mapStateToProps, {

--- a/mobile/src/screens/auth/Login.tsx
+++ b/mobile/src/screens/auth/Login.tsx
@@ -18,7 +18,7 @@ import {
   heightPercentageToDP as hp,
   widthPercentageToDP as wp,
 } from 'react-native-responsive-screen';
-import {loadUser, login} from '../../actions/auth';
+import {login} from '../../actions/auth';
 import {connect} from 'react-redux';
 import {clearErrors, getErrors} from '../../actions/error';
 import {IError} from '../../reducers/error';
@@ -64,12 +64,11 @@ const Login = ({
   useEffect(() => {
     setKeyboardListeners();
     clearErrors();
-    loadUser();
 
     return function cleanup() {
       setKeyboardStatus(undefined);
     };
-  }, [clearErrors, loadUser]);
+  }, [clearErrors]);
 
   useEffect(() => {
     // If authenticated redirect
@@ -198,5 +197,4 @@ export default connect(mapStateToProps, {
   login,
   clearErrors,
   getErrors,
-  loadUser,
 })(Login);

--- a/mobile/src/screens/auth/Register/RegisterStepTwo.tsx
+++ b/mobile/src/screens/auth/Register/RegisterStepTwo.tsx
@@ -30,7 +30,7 @@ interface IRegisterStepTwoProps {
   route: any;
   authenticate: Function;
   error: IError;
-  isLoading: boolean;
+  isAuthenticating: boolean;
   getErrors: Function;
   clearErrors: Function;
 }
@@ -53,7 +53,7 @@ const RegisterStepTwo = ({
   route,
   authenticate,
   error,
-  isLoading,
+  isAuthenticating,
   getErrors,
   clearErrors,
 }: IRegisterStepTwoProps) => {
@@ -156,7 +156,7 @@ const RegisterStepTwo = ({
 
         <View style={styles.mainCTAContainer}>
           <TouchableOpacity style={styles.mainCTA} onPress={onSubmit}>
-            {isLoading && (
+            {isAuthenticating && (
               <ActivityIndicator
                 style={{
                   left: wp(-15),
@@ -194,7 +194,7 @@ const RegisterStepTwo = ({
 const mapStateToProps = (state: any) => ({
   error: state.error,
   isAuthenticated: state.auth.isAuthenticated,
-  isLoading: state.auth.isLoading,
+  isAuthenticating: state.auth.isAuthenticating,
 });
 
 export default connect(mapStateToProps, {


### PR DESCRIPTION
Implementación de ruteo de acuerdo a autenticación en mobile y componente loader.

Después vemos bien cuales son las rutas que corresponderían para cuando esta logueado y para cuando no.
Actualmente, el drawer, cuando no esta logueado únicamente muestra el login.

Y el stack navigator, cuando no esta logueado no se muestra el drawer directamente, por el momento me parece bien, después vemos bien como organizamos eso, lo importante es que funque, cuando alguien no esta logueado no va a tener accesos a rutas que no le corresponde (porque ni siquiera van a ser conocidas por el navigator, no existirían).
Acá esta la docu de como se hace el manejo y mepa que esta bien:

https://reactnavigation.org/docs/auth-flow/

